### PR TITLE
🐛 Stop `diff()` emitting lone surrogates after semantic cleanup

### DIFF
--- a/src/Delta.ts
+++ b/src/Delta.ts
@@ -32,6 +32,9 @@ const getEmbedTypeAndData = (
   return [embedType, a[embedType], b[embedType]];
 };
 
+const hasLoneSurrogate = (diffs: diff.Diff[]): boolean =>
+  diffs.some(([, text]) => /\p{Cs}/u.test(text));
+
 class Delta {
   static Op = Op;
   static OpIterator = OpIterator;
@@ -352,7 +355,12 @@ class Delta {
         .join('');
     });
     const retDelta = new Delta();
-    const diffResult = diff(strings[0], strings[1], cursor, true);
+    let diffResult = diff(strings[0], strings[1], cursor, true);
+    // `fast-diff` fixes up surrogate pairs before its semantic cleanup, which
+    // can then re-split them; its uncleaned diff never does
+    if (hasLoneSurrogate(diffResult)) {
+      diffResult = diff(strings[0], strings[1], cursor, false);
+    }
     const thisIter = new OpIterator(this.ops);
     const otherIter = new OpIterator(other.ops);
     diffResult.forEach((component: diff.Diff) => {

--- a/test/delta/diff.ts
+++ b/test/delta/diff.ts
@@ -157,4 +157,37 @@ describe('diff()', () => {
       a.diff(b);
     }).toThrow(new Error('diff() called on non-document'));
   });
+
+  describe('surrogate pairs', () => {
+    it('insert between astral characters', () => {
+      const a = new Delta().insert('x🌀');
+      const b = new Delta().insert('x🏆🌀');
+      const expected = new Delta().retain(1).insert('🏆');
+      expect(a.diff(b)).toEqual(expected);
+    });
+
+    it('delete an astral character', () => {
+      const a = new Delta().insert('x🌀🎉');
+      const b = new Delta().insert('x🎉');
+      const expected = new Delta().retain(1).delete(2);
+      expect(a.diff(b)).toEqual(expected);
+    });
+
+    it('attributed insert between astral characters', () => {
+      const a = new Delta().insert('x🌀');
+      const b = new Delta()
+        .insert('x')
+        .insert('🏆', { bold: true })
+        .insert('🌀');
+      const expected = new Delta().retain(1).insert('🏆', { bold: true });
+      expect(a.diff(b)).toEqual(expected);
+    });
+
+    it('keeps semantic cleanup when no pair is split', () => {
+      const a = new Delta().insert('🏆Badcat');
+      const b = new Delta().insert('🏆Gooddog');
+      const expected = new Delta().retain(2).insert('Gooddog').delete(6);
+      expect(a.diff(b)).toEqual(expected);
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/slab/delta/issues/115

`diff()` runs `fast-diff` with semantic cleanup enabled. `fast-diff` only applies its unicode-aware merge in the pass that runs *before* cleanup: `diff_cleanupSemantic()` then merges again without the flag, re-splitting the surrogate pairs the first pass protected.

The result is ops holding half an astral character. Composing them still gives the right document, since the halves rejoin across op boundaries, but a lone surrogate has no UTF-8 encoding, so anything that serialises an op on its own to bytes mangles or rejects it.

This change falls back to the uncleaned diff when the cleaned one splits a pair, since the plain diff is surrogate-safe by construction. Those rare diffs then come back character-aligned rather than word-aligned. Fixing this in `fast-diff` would be preferable, but it hasn't had a release since May 2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

